### PR TITLE
Detail page + smaller features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,5 +47,5 @@ features = [
 
 [profile.release]
 lto = true
-opt-level = 's'
-
+opt-level = 'z'
+codegen-units = 1

--- a/less/common/MetaPreview/styles.less
+++ b/less/common/MetaPreview/styles.less
@@ -112,7 +112,7 @@
         flex-wrap: wrap;
         padding: 0 1rem;
 
-        .action-button {
+        .meta-preview-action-button {
             flex: none;
             width: 6rem;
             height: 6rem;

--- a/less/routes/Detail/StreamsList/Stream/styles.less
+++ b/less/routes/Detail/StreamsList/Stream/styles.less
@@ -9,7 +9,7 @@
         background-color: var(--color-surfacedarker);
     }
 
-    .addon-container {
+    .stream-addon-container {
         flex: none;
         padding: 0.5rem;
 

--- a/less/routes/Detail/StreamsList/StreamPlaceholder/styles.less
+++ b/less/routes/Detail/StreamsList/StreamPlaceholder/styles.less
@@ -4,7 +4,7 @@
     align-items: center;
     background-color: var(--color-placeholder);
 
-    .addon-container {
+    .stream-addon-container {
         flex: none;
         padding: 0.5rem;
 

--- a/scripts/bundle.rs
+++ b/scripts/bundle.rs
@@ -1,6 +1,8 @@
 //# fs_extra = "*"
+//# remove_dir_all = "*"
 
 use std::{fs, path::Path};
+use remove_dir_all::remove_dir_all;
 
 const DIST_DIR: &str = "dist";
 
@@ -13,7 +15,7 @@ fn main() {
 
 fn prepare_dist_directory() {
     if Path::new(DIST_DIR).is_dir() {
-        fs::remove_dir_all(DIST_DIR).expect("remove dist directory");
+        remove_dir_all(DIST_DIR).expect("remove dist directory");
     }
     fs::create_dir(DIST_DIR).expect("create dist directory");
 }

--- a/src/entity/multi_select.rs
+++ b/src/entity/multi_select.rs
@@ -55,10 +55,10 @@ pub enum Msg {
 
 // @TODO: remove after Msg::ItemClicked refactor
 #[allow(clippy::collapsible_if)]
-pub fn update<T: 'static + Debug, ParentMsg>(
+pub fn update<T: 'static + Debug, ParentMsg, GMs>(
     msg: Msg,
     model: &mut Model,
-    orders: &mut impl Orders<Msg>,
+    orders: &mut impl Orders<Msg, GMs>,
     mut groups: Vec<Group<T>>,
     on_change: impl FnOnce(Vec<Group<T>>) -> ParentMsg,
 ) -> Option<ParentMsg> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,7 @@ fn sink(g_msg: GMsg, _: &mut Model, orders: &mut impl Orders<Msg, GMsg>) {
 enum Msg {
     RouteChanged(Route),
     DiscoverMsg(page::discover::Msg),
+    DetailMsg(page::detail::Msg),
     AddonsMsg(page::addons::Msg),
 }
 
@@ -116,6 +117,11 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) {
                 );
             }
         }
+        Msg::DetailMsg(module_msg) => {
+            if let Model::Detail(module_model) = model {
+                page::detail::update(module_msg, module_model, &mut orders.proxy(Msg::DetailMsg));
+            }
+        },
         Msg::AddonsMsg(module_msg) => {
             if let Model::Addons(module_model) = model {
                 page::addons::update(module_msg, module_model, &mut orders.proxy(Msg::AddonsMsg));
@@ -128,7 +134,9 @@ fn change_model_by_route(route: Route, model: &mut Model, orders: &mut impl Orde
     let shared_model = SharedModel::from(take(model));
     *model = match route {
         Route::Board => Model::Board(shared_model),
-        Route::Detail { type_name, id, video_id } => Model::Detail(page::detail::init(shared_model, type_name, id, video_id)),
+        Route::Detail { type_name, id, video_id } => {
+            Model::Detail(page::detail::init(shared_model, type_name, id, video_id, &mut orders.proxy(Msg::DetailMsg)))
+        },
         Route::Discover(resource_request) => Model::Discover(page::discover::init(
             shared_model,
             resource_request,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,22 @@ fn routes(url: Url) -> Option<Msg> {
 }
 
 // ------ ------
+//     Sink
+// ------ ------
+
+pub enum GMsg {
+    RoutePushed(Route),
+}
+
+fn sink(g_msg: GMsg, _: &mut Model, orders: &mut impl Orders<Msg, GMsg>) {
+    match g_msg {
+        GMsg::RoutePushed(route) => {
+            orders.send_msg(Msg::RouteChanged(route))
+        }
+    };
+}
+
+// ------ ------
 //    Update
 // ------ ------
 
@@ -86,7 +102,7 @@ enum Msg {
     AddonsMsg(page::addons::Msg),
 }
 
-fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
+fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) {
     match msg {
         Msg::RouteChanged(route) => {
             change_model_by_route(route, model, orders);
@@ -108,7 +124,7 @@ fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
     }
 }
 
-fn change_model_by_route(route: Route, model: &mut Model, orders: &mut impl Orders<Msg>) {
+fn change_model_by_route(route: Route, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) {
     let shared_model = SharedModel::from(take(model));
     *model = match route {
         Route::Board => Model::Board(shared_model),
@@ -158,5 +174,5 @@ fn view(model: &Model) -> impl View<Msg> {
 
 #[wasm_bindgen(start)]
 pub fn start() {
-    App::builder(update, view).routes(routes).build_and_start();
+    App::builder(update, view).routes(routes).sink(sink).build_and_start();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,8 +109,8 @@ fn sink(g_msg: GMsg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) {
     };
 
     let unhandled_g_msg = match model {
-        Model::Discover(_) => page::discover::sink(g_msg, &mut orders.proxy(Msg::DiscoverMsg)),
-        Model::Addons(_) => page::addons::sink(g_msg, &mut orders.proxy(Msg::AddonsMsg)),
+        Model::Discover(module_model) => page::discover::sink(g_msg, module_model, &mut orders.proxy(Msg::DiscoverMsg)),
+        Model::Addons(module_model) => page::addons::sink(g_msg, module_model, &mut orders.proxy(Msg::AddonsMsg)),
         Model::Redirect |
         Model::Board(_) |
         Model::Detail(_) |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ use stremio_derive::Model;
 pub enum Model {
     Redirect,
     Board(SharedModel),
-    Detail(SharedModel),
+    Detail(page::detail::Model),
     Discover(page::discover::Model),
     Player(SharedModel),
     Addons(page::addons::Model),
@@ -48,9 +48,9 @@ impl From<Model> for SharedModel {
         match model {
             Model::Redirect => Self::default(),
             Model::Discover(module_model) => module_model.into(),
+            Model::Detail(module_model) => module_model.into(),
             Model::Addons(module_model) => module_model.into(),
             Model::Board(shared_model)
-            | Model::Detail(shared_model)
             | Model::Player(shared_model)
             | Model::NotFound(shared_model) => shared_model,
         }
@@ -112,7 +112,7 @@ fn change_model_by_route(route: Route, model: &mut Model, orders: &mut impl Orde
     let shared_model = SharedModel::from(take(model));
     *model = match route {
         Route::Board => Model::Board(shared_model),
-        Route::Detail => Model::Detail(shared_model),
+        Route::Detail { type_name, id, video_id } => Model::Detail(page::detail::init(shared_model, type_name, id, video_id)),
         Route::Discover(resource_request) => Model::Discover(page::discover::init(
             shared_model,
             resource_request,

--- a/src/page/addons.rs
+++ b/src/page/addons.rs
@@ -79,14 +79,20 @@ fn load_catalog(resource_request: Option<ResourceRequest>,orders: &mut impl Orde
 //     Sink
 // ------ ------
 
-pub fn sink(g_msg: GMsg, orders: &mut impl Orders<Msg, GMsg>) -> Option<GMsg> {
+pub fn sink(g_msg: GMsg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) -> Option<GMsg> {
     match g_msg {
         GMsg::GoTo(Route::Addons(resource_request)) => {
             load_catalog(resource_request, orders);
-            None
+            return None;
         },
-        _ => Some(g_msg)
+        GMsg::Core(ref core_msg) => {
+            if let CoreMsg::Action(Action::Load(ActionLoad::CatalogFiltered(_))) = core_msg.as_ref() {
+                model.search_query = String::new();
+            }
+        },
+        _ => ()
     }
+    Some(g_msg)
 }
 
 // ------ ------

--- a/src/page/addons.rs
+++ b/src/page/addons.rs
@@ -1,4 +1,4 @@
-use crate::{entity::multi_select, route::Route, SharedModel, GMsg};
+use crate::{entity::multi_select, route::Route, GMsg, SharedModel};
 use modal::Modal;
 use seed::{prelude::*, *};
 use std::rc::Rc;
@@ -69,7 +69,7 @@ pub fn init(
     }
 }
 
-fn load_catalog(resource_request: Option<ResourceRequest>,orders: &mut impl Orders<Msg, GMsg>) {
+fn load_catalog(resource_request: Option<ResourceRequest>, orders: &mut impl Orders<Msg, GMsg>) {
     orders.send_g_msg(GMsg::Core(Rc::new(CoreMsg::Action(Action::Load(
         ActionLoad::CatalogFiltered(resource_request.unwrap_or_else(default_resource_request)),
     )))));
@@ -84,13 +84,14 @@ pub fn sink(g_msg: GMsg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>)
         GMsg::GoTo(Route::Addons(resource_request)) => {
             load_catalog(resource_request, orders);
             return None;
-        },
+        }
         GMsg::Core(ref core_msg) => {
-            if let CoreMsg::Action(Action::Load(ActionLoad::CatalogFiltered(_))) = core_msg.as_ref() {
+            if let CoreMsg::Action(Action::Load(ActionLoad::CatalogFiltered(_))) = core_msg.as_ref()
+            {
                 model.search_query = String::new();
             }
-        },
-        _ => ()
+        }
+        _ => (),
     }
     Some(g_msg)
 }
@@ -134,7 +135,7 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) 
         }
         Msg::CatalogSelectorChanged(groups_with_selected_items) => {
             let req = catalog_selector::resource_request(groups_with_selected_items);
-            orders.send_g_msg(GMsg::GoTo(Route::Addons(Some(req.clone()))));
+            orders.send_g_msg(GMsg::GoTo(Route::Addons(Some(req))));
         }
 
         // ------ TypeSelector  ------
@@ -156,7 +157,7 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) 
         }
         Msg::TypeSelectorChanged(groups_with_selected_items) => {
             let req = type_selector::resource_request(groups_with_selected_items);
-            orders.send_g_msg(GMsg::GoTo(Route::Addons(Some(req.clone()))));
+            orders.send_g_msg(GMsg::GoTo(Route::Addons(Some(req))));
         }
 
         Msg::SearchQueryChanged(search_query) => model.search_query = search_query,

--- a/src/page/addons.rs
+++ b/src/page/addons.rs
@@ -1,4 +1,4 @@
-use crate::{entity::multi_select, route::Route, SharedModel};
+use crate::{entity::multi_select, route::Route, SharedModel, GMsg};
 use futures::future::Future;
 use modal::Modal;
 use seed::{prelude::*, *};
@@ -53,7 +53,7 @@ impl From<Model> for SharedModel {
 pub fn init(
     shared: SharedModel,
     resource_request: Option<ResourceRequest>,
-    orders: &mut impl Orders<Msg>,
+    orders: &mut impl Orders<Msg, GMsg>,
 ) -> Model {
     orders.send_msg(
         // @TODO try to remove `Clone` requirement from Seed or add it into stremi-core? Implement intos, from etc.?
@@ -94,7 +94,7 @@ pub enum Msg {
     NoOp,
 }
 
-fn push_resource_request(req: ResourceRequest, orders: &mut impl Orders<Msg>) {
+fn push_resource_request(req: ResourceRequest, orders: &mut impl Orders<Msg, GMsg>) {
     let route = Route::Addons(Some(req.clone()));
     let url = Url::try_from(route.to_href()).expect("`Url` from `Route::Addons`");
     seed::push_route(url);
@@ -104,7 +104,7 @@ fn push_resource_request(req: ResourceRequest, orders: &mut impl Orders<Msg>) {
     )))));
 }
 
-pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg>) {
+pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) {
     let catalog = &model.shared.core.addon_catalog;
 
     match msg {

--- a/src/page/addons/catalog_selector.rs
+++ b/src/page/addons/catalog_selector.rs
@@ -1,5 +1,5 @@
 use super::{BASE, MY_ITEM_ID, RESOURCE, TYPE_ALL};
-use crate::entity::multi_select;
+use crate::{entity::multi_select, GMsg};
 use itertools::Itertools;
 use seed::prelude::*;
 use std::fmt::Debug;
@@ -31,7 +31,7 @@ pub struct Msg(multi_select::Msg);
 pub fn update<T: 'static + Debug, ParentMsg>(
     msg: Msg,
     model: &mut Model,
-    orders: &mut impl Orders<Msg>,
+    orders: &mut impl Orders<Msg, GMsg>,
     groups: Vec<multi_select::Group<T>>,
     on_change: impl FnOnce(Vec<multi_select::Group<T>>) -> ParentMsg,
 ) -> Option<ParentMsg> {

--- a/src/page/addons/type_selector.rs
+++ b/src/page/addons/type_selector.rs
@@ -1,5 +1,5 @@
 use super::{BASE, MY_ITEM_ID, RESOURCE, TYPE_ALL};
-use crate::entity::multi_select;
+use crate::{entity::multi_select, GMsg};
 use seed::prelude::*;
 use std::collections::BTreeSet;
 use std::fmt::Debug;
@@ -30,7 +30,7 @@ pub struct Msg(multi_select::Msg);
 pub fn update<T: 'static + Debug, ParentMsg>(
     msg: Msg,
     model: &mut Model,
-    orders: &mut impl Orders<Msg>,
+    orders: &mut impl Orders<Msg, GMsg>,
     groups: Vec<multi_select::Group<T>>,
     on_change: impl FnOnce(Vec<multi_select::Group<T>>) -> ParentMsg,
 ) -> Option<ParentMsg> {

--- a/src/page/detail.rs
+++ b/src/page/detail.rs
@@ -1,9 +1,7 @@
+use crate::{GMsg, SharedModel};
 use seed::{prelude::*, *};
-use crate::{SharedModel, GMsg};
-use stremio_core::state_types::{
-    Action, ActionLoad, Msg as CoreMsg,
-};
 use std::rc::Rc;
+use stremio_core::state_types::{Action, ActionLoad, Msg as CoreMsg};
 
 // ------ ------
 //     Model
@@ -36,18 +34,17 @@ pub fn init(
     video_id: Option<String>,
     orders: &mut impl Orders<Msg, GMsg>,
 ) -> Model {
-
     // @TODO refactor and integrate
     // @TODO - wait until branch `details_model` or `development` is merged into `master` (?)
-    orders.send_g_msg(
-        GMsg::Core(Rc::new(CoreMsg::Action(Action::Load(
-            ActionLoad::Detail { type_name, id, video_id },
-        )))),
-    );
+    orders.send_g_msg(GMsg::Core(Rc::new(CoreMsg::Action(Action::Load(
+        ActionLoad::Detail {
+            type_name,
+            id,
+            video_id,
+        },
+    )))));
 
-    Model {
-        shared,
-    }
+    Model { shared }
 }
 
 // ------ ------
@@ -55,7 +52,7 @@ pub fn init(
 // ------ ------
 
 #[derive(Clone)]
-pub enum Msg {}
+pub struct Msg;
 
 pub fn update(_: Msg, _: &mut Model, _: &mut impl Orders<Msg, GMsg>) {
     unimplemented!()
@@ -67,14 +64,10 @@ pub fn update(_: Msg, _: &mut Model, _: &mut impl Orders<Msg, GMsg>) {
 
 pub fn view<Ms: 'static>() -> impl View<Ms> {
     div![
-        class![
-            "detail-container",
-        ],
+        class!["detail-container",],
         view_nav(),
         div![
-            class![
-                "detail-content"
-            ],
+            class!["detail-content"],
             view_background_image_layer(),
             view_meta_preview_container(),
             // @TODO switch by `type_name` (?)
@@ -89,17 +82,14 @@ pub fn view<Ms: 'static>() -> impl View<Ms> {
 
 fn view_nav<Ms: 'static>() -> Node<Ms> {
     div![
-        class![
-            "nav-bar",
-            "nav-bar-container",
-        ],
+        class!["nav-bar", "nav-bar-container",],
         div![
             class![
                 "nav-tab-button",
                 "nav-tab-button-container",
                 "button-container",
             ],
-            attrs!{
+            attrs! {
                 At::TabIndex => -1,
                 At::Title => "back",
             },
@@ -113,19 +103,9 @@ fn view_nav<Ms: 'static>() -> Node<Ms> {
                     At::D => "M607.473 926.419l-412.009-414.419 412.009-414.419-97.28-97.581-510.193 512 510.193 512z"
                 }]
             ],
-            div![
-                class![
-                    "label",
-                ],
-                "Back"
-            ]
+            div![class!["label",], "Back"]
         ],
-        h2![
-            class![
-                "title"
-            ],
-            "Underworld",
-        ]
+        h2![class!["title"], "Underworld",]
     ]
 }
 
@@ -133,14 +113,10 @@ fn view_nav<Ms: 'static>() -> Node<Ms> {
 
 fn view_background_image_layer<Ms: 'static>() -> Node<Ms> {
     div![
-        class![
-            "background-image-layer"
-        ],
+        class!["background-image-layer"],
         img![
-            class![
-                "background-image"
-            ],
-            attrs!{
+            class!["background-image"],
+            attrs! {
                 At::Src => "https://images.metahub.space/background/medium/tt0320691/img",
                 At::Alt => " ",
             }
@@ -152,10 +128,7 @@ fn view_background_image_layer<Ms: 'static>() -> Node<Ms> {
 
 fn view_meta_preview_container<Ms: 'static>() -> Node<Ms> {
     div![
-        class![
-            "meta-preview",
-            "meta-preview-container",
-        ],
+        class!["meta-preview", "meta-preview-container",],
         view_meta_info_container(),
         view_action_buttons_container(),
     ]
@@ -207,76 +180,24 @@ fn view_meta_info_container<Ms: 'static>() -> Node<Ms> {
 fn view_meta_links_containers<Ms: 'static>() -> Vec<Node<Ms>> {
     vec![
         div![
-            class![
-                "meta-links",
-                "meta-links-container"
-            ],
-            div![
-                class![
-                    "label-container",
-                ],
-                "Genres:"
-            ],
-            div![
-                class![
-                    "links-container"
-                ],
-                view_genres(),
-            ]
+            class!["meta-links", "meta-links-container"],
+            div![class!["label-container",], "Genres:"],
+            div![class!["links-container"], view_genres(),]
         ],
         div![
-            class![
-                "meta-links",
-                "meta-links-container"
-            ],
-            div![
-                class![
-                    "label-container",
-                ],
-                "Writers:"
-            ],
-            div![
-                class![
-                    "links-container"
-                ],
-                view_writers(),
-            ]
+            class!["meta-links", "meta-links-container"],
+            div![class!["label-container",], "Writers:"],
+            div![class!["links-container"], view_writers(),]
         ],
         div![
-            class![
-                "meta-links",
-                "meta-links-container"
-            ],
-            div![
-                class![
-                    "label-container",
-                ],
-                "Directors:"
-            ],
-            div![
-                class![
-                    "links-container"
-                ],
-                view_directors(),
-            ]
+            class!["meta-links", "meta-links-container"],
+            div![class!["label-container",], "Directors:"],
+            div![class!["links-container"], view_directors(),]
         ],
         div![
-            class![
-                "meta-links",
-                "meta-links-container"
-            ],
-            div![
-                class![
-                    "label-container",
-                ],
-                "Cast:"
-            ],
-            div![
-                class![
-                    "links-container"
-                ],
-                view_cast(),
-            ]
+            class!["meta-links", "meta-links-container"],
+            div![class!["label-container",], "Cast:"],
+            div![class!["links-container"], view_cast(),]
         ],
     ]
 }
@@ -284,11 +205,8 @@ fn view_meta_links_containers<Ms: 'static>() -> Vec<Node<Ms>> {
 fn view_genres<Ms: 'static>() -> Vec<Node<Ms>> {
     vec![
         a![
-            class![
-                "link-container",
-                "button-container",
-            ],
-            attrs!{
+            class!["link-container", "button-container",],
+            attrs! {
                 At::TabIndex => -1,
                 At::Title => "Action",
                 At::Href => "#/discover/xxx/yyy/?genre=Action"
@@ -296,11 +214,8 @@ fn view_genres<Ms: 'static>() -> Vec<Node<Ms>> {
             "Action, "
         ],
         a![
-            class![
-                "link-container",
-                "button-container",
-            ],
-            attrs!{
+            class!["link-container", "button-container",],
+            attrs! {
                 At::TabIndex => -1,
                 At::Title => "Fantasy",
                 At::Href => "#/discover/xxx/yyy/?genre=Fantasy"
@@ -308,11 +223,8 @@ fn view_genres<Ms: 'static>() -> Vec<Node<Ms>> {
             "Fantasy, "
         ],
         a![
-            class![
-                "link-container",
-                "button-container",
-            ],
-            attrs!{
+            class!["link-container", "button-container",],
+            attrs! {
                 At::TabIndex => -1,
                 At::Title => "Thriller",
                 At::Href => "#/discover/xxx/yyy/?genre=Thriller"
@@ -325,11 +237,8 @@ fn view_genres<Ms: 'static>() -> Vec<Node<Ms>> {
 fn view_writers<Ms: 'static>() -> Vec<Node<Ms>> {
     vec![
         a![
-            class![
-                "link-container",
-                "button-container",
-            ],
-            attrs!{
+            class!["link-container", "button-container",],
+            attrs! {
                 At::TabIndex => -1,
                 At::Title => "Kevin Grevioux",
                 At::Href => "#/search?q=Kevin Grevioux"
@@ -337,11 +246,8 @@ fn view_writers<Ms: 'static>() -> Vec<Node<Ms>> {
             "Kevin Grevioux, "
         ],
         a![
-            class![
-                "link-container",
-                "button-container",
-            ],
-            attrs!{
+            class!["link-container", "button-container",],
+            attrs! {
                 At::TabIndex => -1,
                 At::Title => "Len Wiseman",
                 At::Href => "#/search?q=Len Wiseman"
@@ -349,11 +255,8 @@ fn view_writers<Ms: 'static>() -> Vec<Node<Ms>> {
             "Len Wiseman, "
         ],
         a![
-            class![
-                "link-container",
-                "button-container",
-            ],
-            attrs!{
+            class!["link-container", "button-container",],
+            attrs! {
                 At::TabIndex => -1,
                 At::Title => "Danny McBride",
                 At::Href => "#/search?q=Danny McBride"
@@ -364,30 +267,22 @@ fn view_writers<Ms: 'static>() -> Vec<Node<Ms>> {
 }
 
 fn view_directors<Ms: 'static>() -> Vec<Node<Ms>> {
-    vec![
-        a![
-            class![
-                "link-container",
-                "button-container",
-            ],
-            attrs!{
-                At::TabIndex => -1,
-                At::Title => "Len Wiseman",
-                At::Href => "#/search?q=Len Wiseman"
-            },
-            "Len Wiseman"
-        ],
-    ]
+    vec![a![
+        class!["link-container", "button-container",],
+        attrs! {
+            At::TabIndex => -1,
+            At::Title => "Len Wiseman",
+            At::Href => "#/search?q=Len Wiseman"
+        },
+        "Len Wiseman"
+    ]]
 }
 
 fn view_cast<Ms: 'static>() -> Vec<Node<Ms>> {
     vec![
         a![
-            class![
-                "link-container",
-                "button-container",
-            ],
-            attrs!{
+            class!["link-container", "button-container",],
+            attrs! {
                 At::TabIndex => -1,
                 At::Title => "Kate Beckinsale",
                 At::Href => "#/search?q=Kate Beckinsale"
@@ -395,11 +290,8 @@ fn view_cast<Ms: 'static>() -> Vec<Node<Ms>> {
             "Kate Beckinsale, "
         ],
         a![
-            class![
-                "link-container",
-                "button-container",
-            ],
-            attrs!{
+            class!["link-container", "button-container",],
+            attrs! {
                 At::TabIndex => -1,
                 At::Title => "Scott Speedman",
                 At::Href => "#/search?q=Scott Speedman"
@@ -407,11 +299,8 @@ fn view_cast<Ms: 'static>() -> Vec<Node<Ms>> {
             "Scott Speedman, "
         ],
         a![
-            class![
-                "link-container",
-                "button-container",
-            ],
-            attrs!{
+            class!["link-container", "button-container",],
+            attrs! {
                 At::TabIndex => -1,
                 At::Title => "Michael Sheen",
                 At::Href => "#/search?q=Michael Sheen"
@@ -419,11 +308,8 @@ fn view_cast<Ms: 'static>() -> Vec<Node<Ms>> {
             "Michael Sheen, "
         ],
         a![
-            class![
-                "link-container",
-                "button-container",
-            ],
-            attrs!{
+            class!["link-container", "button-container",],
+            attrs! {
                 At::TabIndex => -1,
                 At::Title => "Shane Brolly",
                 At::Href => "#/search?q=Shane Brolly"
@@ -437,9 +323,7 @@ fn view_cast<Ms: 'static>() -> Vec<Node<Ms>> {
 
 fn view_action_buttons_container<Ms: 'static>() -> Node<Ms> {
     div![
-        class![
-            "action-buttons-container",
-        ],
+        class!["action-buttons-container",],
         view_action_button_add_to_library(),
         view_action_button_trailer(),
         view_action_button_imdb(),
@@ -454,14 +338,12 @@ fn view_action_button_add_to_library<Ms: 'static>() -> Node<Ms> {
             "action-button-container",
             "button-container",
         ],
-        attrs!{
+        attrs! {
             At::TabIndex => -1,
             At::Title => "Add to library"
         },
         div![
-            class![
-                "icon-container",
-            ],
+            class!["icon-container",],
             svg![
                 class!["icon",],
                 attrs! {
@@ -486,15 +368,8 @@ fn view_action_button_add_to_library<Ms: 'static>() -> Node<Ms> {
             ],
         ],
         div![
-            class![
-                "label-container",
-            ],
-            div![
-                class![
-                    "label"
-                ],
-                "Add to library",
-            ]
+            class!["label-container",],
+            div![class!["label"], "Add to library",]
         ]
     ]
 }
@@ -506,15 +381,13 @@ fn view_action_button_trailer<Ms: 'static>() -> Node<Ms> {
             "action-button-container",
             "button-container",
         ],
-        attrs!{
+        attrs! {
             At::TabIndex => 0,
             At::Title => "Trailer",
             At::Href => "#/player?stream=mn4O3iQ8B_s",
         },
         div![
-            class![
-                "icon-container",
-            ],
+            class!["icon-container",],
             svg![
                 class!["icon",],
                 attrs! {
@@ -533,15 +406,8 @@ fn view_action_button_trailer<Ms: 'static>() -> Node<Ms> {
             ],
         ],
         div![
-            class![
-                "label-container",
-            ],
-            div![
-                class![
-                    "label"
-                ],
-                "Trailer",
-            ]
+            class!["label-container",],
+            div![class!["label"], "Trailer",]
         ]
     ]
 }
@@ -553,16 +419,14 @@ fn view_action_button_imdb<Ms: 'static>() -> Node<Ms> {
             "action-button-container",
             "button-container",
         ],
-        attrs!{
+        attrs! {
             At::TabIndex => 0,
             At::Title => "7.0 / 10",
             At::Href => "https://imdb.com/title/tt0320691",
             At::Target => "_blank",
         },
         div![
-            class![
-                "icon-container",
-            ],
+            class!["icon-container",],
             svg![
                 class!["icon",],
                 attrs! {
@@ -587,15 +451,8 @@ fn view_action_button_imdb<Ms: 'static>() -> Node<Ms> {
             ],
         ],
         div![
-            class![
-                "label-container",
-            ],
-            div![
-                class![
-                    "label"
-                ],
-                "7.0 / 10",
-            ]
+            class!["label-container",],
+            div![class!["label"], "7.0 / 10",]
         ]
     ]
 }
@@ -607,14 +464,12 @@ fn view_action_button_share<Ms: 'static>() -> Node<Ms> {
             "action-button-container",
             "button-container",
         ],
-        attrs!{
+        attrs! {
             At::TabIndex => -1,
             At::Title => "Share"
         },
         div![
-            class![
-                "icon-container",
-            ],
+            class!["icon-container",],
             svg![
                 class!["icon",],
                 attrs! {
@@ -626,17 +481,7 @@ fn view_action_button_share<Ms: 'static>() -> Node<Ms> {
                 }],
             ],
         ],
-        div![
-            class![
-                "label-container",
-            ],
-            div![
-                class![
-                    "label"
-                ],
-                "Share",
-            ]
-        ]
+        div![class!["label-container",], div![class!["label"], "Share",]]
     ]
 }
 
@@ -644,51 +489,26 @@ fn view_action_button_share<Ms: 'static>() -> Node<Ms> {
 
 fn view_streams_list_container<Ms: 'static>() -> Node<Ms> {
     div![
-        class![
-            "streams-list",
-            "streams-list-container",
-        ],
+        class!["streams-list", "streams-list-container",],
         div![
-            class![
-                "streams-scroll-container",
-            ],
+            class!["streams-scroll-container",],
             // stream
             div![
-                class![
-                    "stream",
-                    "stream-container",
-                    "button-container",
-                ],
-                attrs!{
+                class!["stream", "stream-container", "button-container",],
+                attrs! {
                     At::TabIndex => 0,
                     At::Title => "Google Sample Videos",
                 },
                 div![
-                    class![
-                        "stream-addon-container",
-                    ],
-                    div![
-                        class![
-                            "addon-name",
-                        ],
-                        "Google",
-                    ]
+                    class!["stream-addon-container",],
+                    div![class!["addon-name",], "Google",]
                 ],
                 div![
-                    class![
-                        "info-container",
-                    ],
-                    div![
-                        class![
-                            "description-label",
-                        ],
-                        "Google sample videos",
-                    ]
+                    class!["info-container",],
+                    div![class!["description-label",], "Google sample videos",]
                 ],
                 div![
-                    class![
-                        "play-icon-container",
-                    ],
+                    class!["play-icon-container",],
                     svg![
                         class!["play-icon",],
                         attrs! {
@@ -703,41 +523,21 @@ fn view_streams_list_container<Ms: 'static>() -> Node<Ms> {
             ],
             // stream
             div![
-                class![
-                    "stream",
-                    "stream-container",
-                    "button-container",
-                ],
-                attrs!{
+                class!["stream", "stream-container", "button-container",],
+                attrs! {
                     At::TabIndex => 0,
                     At::Title => "Stremio demo videos",
                 },
                 div![
-                    class![
-                        "stream-addon-container",
-                    ],
-                    div![
-                        class![
-                            "addon-name",
-                        ],
-                        "Stremio",
-                    ]
+                    class!["stream-addon-container",],
+                    div![class!["addon-name",], "Stremio",]
                 ],
                 div![
-                    class![
-                        "info-container",
-                    ],
-                    div![
-                        class![
-                            "description-label",
-                        ],
-                        "Stremio demo videos",
-                    ]
+                    class!["info-container",],
+                    div![class!["description-label",], "Stremio demo videos",]
                 ],
                 div![
-                    class![
-                        "play-icon-container",
-                    ],
+                    class!["play-icon-container",],
                     svg![
                         class!["play-icon",],
                         attrs! {
@@ -750,14 +550,10 @@ fn view_streams_list_container<Ms: 'static>() -> Node<Ms> {
                     ],
                 ],
                 div![
-                    class![
-                        "progress-bar-container",
-                    ],
+                    class!["progress-bar-container",],
                     div![
-                        class![
-                            "progress-bar",
-                        ],
-                        style!{
+                        class!["progress-bar",],
+                        style! {
                             St::Width => unit!(30, %),
                         }
                     ]
@@ -770,11 +566,8 @@ fn view_streams_list_container<Ms: 'static>() -> Node<Ms> {
 
 fn view_install_addons_button<Ms: 'static>() -> Node<Ms> {
     a![
-        class![
-            "install-addons-container",
-            "button-container",
-        ],
-        attrs!{
+        class!["install-addons-container", "button-container",],
+        attrs! {
             At::TabIndex => 0,
             At::Title => "Install addons",
             At::Href => "#/addons",
@@ -789,12 +582,7 @@ fn view_install_addons_button<Ms: 'static>() -> Node<Ms> {
                 At::D => "M145.468 679.454c-40.056-39.454-80.715-78.908-120.471-118.664-33.431-33.129-33.129-60.235 0-90.353l132.216-129.807c5.693-5.938 12.009-11.201 18.865-15.709l0.411-0.253c23.492-15.059 41.864-7.529 48.188 18.974 0 7.228 2.711 14.758 3.614 22.287 3.801 47.788 37.399 86.785 82.050 98.612l0.773 0.174c10.296 3.123 22.128 4.92 34.381 4.92 36.485 0 69.247-15.94 91.702-41.236l0.11-0.126c24.858-21.654 40.48-53.361 40.48-88.718 0-13.746-2.361-26.941-6.701-39.201l0.254 0.822c-14.354-43.689-53.204-75.339-99.907-78.885l-0.385-0.023c-18.372-2.409-41.562 0-48.188-23.492s11.445-34.635 24.998-47.887q65.054-62.946 130.409-126.795c32.527-31.925 60.235-32.226 90.353 0 40.659 39.153 80.715 78.908 120.471 118.362 8.348 8.594 17.297 16.493 26.82 23.671l0.587 0.424c8.609 7.946 20.158 12.819 32.846 12.819 24.823 0 45.29-18.653 48.148-42.707l0.022-0.229c3.012-13.252 4.518-26.805 8.734-39.755 12.103-42.212 50.358-72.582 95.705-72.582 3.844 0 7.637 0.218 11.368 0.643l-0.456-0.042c54.982 6.832 98.119 49.867 105.048 104.211l0.062 0.598c0.139 1.948 0.218 4.221 0.218 6.512 0 45.084-30.574 83.026-72.118 94.226l-0.683 0.157c-12.348 3.915-25.299 5.722-37.948 8.433-45.779 9.638-60.235 46.984-30.118 82.824 15.265 17.569 30.806 33.587 47.177 48.718l0.409 0.373c31.925 31.925 64.452 62.946 96.075 94.871 13.698 9.715 22.53 25.511 22.53 43.369s-8.832 33.655-22.366 43.259l-0.164 0.111c-45.176 45.176-90.353 90.353-137.035 134.325-5.672 5.996-12.106 11.184-19.169 15.434l-0.408 0.227c-4.663 3.903-10.725 6.273-17.341 6.273-13.891 0-25.341-10.449-26.92-23.915l-0.012-0.127c-2.019-7.447-3.714-16.45-4.742-25.655l-0.077-0.848c-4.119-47.717-38.088-86.476-82.967-97.721l-0.76-0.161c-9.584-2.63-20.589-4.141-31.947-4.141-39.149 0-74.105 17.956-97.080 46.081l-0.178 0.225c-21.801 21.801-35.285 51.918-35.285 85.185 0 1.182 0.017 2.36 0.051 3.533l-0.004-0.172c1.534 53.671 40.587 97.786 91.776 107.115l0.685 0.104c12.649 2.409 25.901 3.313 38.249 6.626 22.588 6.325 30.118 21.685 18.372 41.864-4.976 8.015-10.653 14.937-17.116 21.035l-0.051 0.047c-44.875 44.574-90.353 90.353-135.228 133.12-10.241 14.067-26.653 23.106-45.176 23.106s-34.935-9.039-45.066-22.946l-0.111-0.159c-40.659-38.852-80.414-78.908-120.471-118.362z"
             }],
         ],
-        div![
-            class![
-                "label",
-            ],
-            "Install addons",
-        ]
+        div![class!["label",], "Install addons",]
     ]
 }
 
@@ -802,10 +590,7 @@ fn view_install_addons_button<Ms: 'static>() -> Node<Ms> {
 
 fn view_videos_list_container<Ms: 'static>() -> Node<Ms> {
     div![
-        class![
-            "videos-list",
-            "videos-list-container",
-        ],
+        class!["videos-list", "videos-list-container",],
         view_season_bar_container(),
         view_video_scroll_container(),
     ]
@@ -813,16 +598,10 @@ fn view_videos_list_container<Ms: 'static>() -> Node<Ms> {
 
 fn view_season_bar_container<Ms: 'static>() -> Node<Ms> {
     div![
-        class![
-            "seasons-bar",
-            "seasons-bar-container",
-        ],
+        class!["seasons-bar", "seasons-bar-container",],
         div![
-            class![
-                "prev-season-button",
-                "button-container",
-            ],
-            attrs!{
+            class!["prev-season-button", "button-container",],
+            attrs! {
                 At::TabIndex => 0,
             },
             svg![
@@ -837,33 +616,17 @@ fn view_season_bar_container<Ms: 'static>() -> Node<Ms> {
             ],
         ],
         div![
-            class![
-                "seasons-popup-label-container",
-                "button-container",
-            ],
-            attrs!{
+            class!["seasons-popup-label-container", "button-container",],
+            attrs! {
                 At::TabIndex => 0,
                 At::Title => "Season 1",
             },
-            div![
-                class![
-                    "season-label"
-                ],
-                "Season",
-            ],
-            div![
-                class![
-                    "number-label",
-                ],
-                "1",
-            ]
+            div![class!["season-label"], "Season",],
+            div![class!["number-label",], "1",]
         ],
         div![
-            class![
-                "next-season-button",
-                "button-container",
-            ],
-            attrs!{
+            class!["next-season-button", "button-container",],
+            attrs! {
                 At::TabIndex => 0,
             },
             svg![
@@ -882,54 +645,33 @@ fn view_season_bar_container<Ms: 'static>() -> Node<Ms> {
 
 fn view_video_scroll_container<Ms: 'static>() -> Node<Ms> {
     div![
-        class![
-            "videos-scroll-container",
-        ],
+        class!["videos-scroll-container",],
         div![
-            class![
-                "video",
-                "video-container",
-                "button-container",
-            ],
-            attrs!{
+            class!["video", "video-container", "button-container",],
+            attrs! {
                 At::TabIndex => 0,
                 At::Title => "How to create a Stremio add-on with Node.js",
             },
             div![
-                class![
-                    "poster-container",
-                ],
+                class!["poster-container",],
                 img![
-                    class![
-                        "poster",
-                    ],
-                    attrs!{
+                    class!["poster",],
+                    attrs! {
                         At::Src => "https://theme.zdassets.com/theme_assets/2160011/77a6ad5aee11a07eb9b87281070f1aadf946f2b3.png",
                         At::Alt => " ",
                     }
                 ]
             ],
             div![
-                class![
-                    "info-container",
-                ],
+                class!["info-container",],
                 div![
-                    class![
-                        "name-container",
-                    ],
+                    class!["name-container",],
                     "1. How to create a Stremio add-on with Node.js",
                 ],
-                div![
-                    class![
-                        "released-container",
-                    ],
-                    "Jun 30, 19",
-                ]
+                div![class!["released-container",], "Jun 30, 19",]
             ],
             div![
-                class![
-                    "next-icon-container",
-                ],
+                class!["next-icon-container",],
                 svg![
                     class!["next-icon",],
                     attrs! {

--- a/src/page/detail.rs
+++ b/src/page/detail.rs
@@ -1,4 +1,38 @@
 use seed::{prelude::*, *};
+use crate::SharedModel;
+
+// ------ ------
+//     Model
+// ------ ------
+
+pub struct Model {
+    shared: SharedModel,
+}
+
+impl From<Model> for SharedModel {
+    fn from(model: Model) -> Self {
+        model.shared
+    }
+}
+
+// ------ ------
+//     Init
+// ------ ------
+
+pub fn init(
+    shared: SharedModel,
+    type_name: String,
+    id: String,
+    video_id: Option<String>,
+) -> Model {
+    log!("type_name", type_name);
+    log!("id", id);
+    log!("video_id", video_id);
+
+    Model {
+        shared,
+    }
+}
 
 // ------ ------
 //     View
@@ -16,7 +50,7 @@ pub fn view<Ms: 'static>() -> impl View<Ms> {
             ],
             view_background_image_layer(),
             view_meta_preview_container(),
-            if false {
+            if true {
                 view_streams_list_container()
             } else {
                 view_videos_list_container()

--- a/src/page/detail.rs
+++ b/src/page/detail.rs
@@ -5,5 +5,880 @@ use seed::{prelude::*, *};
 // ------ ------
 
 pub fn view<Ms: 'static>() -> impl View<Ms> {
-    div!["Detail"]
+    div![
+        class![
+            "detail-container",
+        ],
+        view_nav(),
+        div![
+            class![
+                "detail-content"
+            ],
+            view_background_image_layer(),
+            view_meta_preview_container(),
+            if false {
+                view_streams_list_container()
+            } else {
+                view_videos_list_container()
+            }
+        ]
+    ]
+}
+
+fn view_nav<Ms: 'static>() -> Node<Ms> {
+    div![
+        class![
+            "nav-bar",
+            "nav-bar-container",
+        ],
+        div![
+            class![
+                "nav-tab-button",
+                "nav-tab-button-container",
+                "button-container",
+            ],
+            attrs!{
+                At::TabIndex => -1,
+                At::Title => "back",
+            },
+            svg![
+                class!["icon",],
+                attrs! {
+                    At::ViewBox => "0 0 607 1024",
+                    "icon" => "ic_back_ios",
+                },
+                path![attrs! {
+                    At::D => "M607.473 926.419l-412.009-414.419 412.009-414.419-97.28-97.581-510.193 512 510.193 512z"
+                }]
+            ],
+            div![
+                class![
+                    "label",
+                ],
+                "Back"
+            ]
+        ],
+        h2![
+            class![
+                "title"
+            ],
+            "Underworld",
+        ]
+    ]
+}
+
+// ------ view background image ------
+
+fn view_background_image_layer<Ms: 'static>() -> Node<Ms> {
+    div![
+        class![
+            "background-image-layer"
+        ],
+        img![
+            class![
+                "background-image"
+            ],
+            attrs!{
+                At::Src => "https://images.metahub.space/background/medium/tt0320691/img",
+                At::Alt => " ",
+            }
+        ]
+    ]
+}
+
+// ------ view meta preview ------
+
+fn view_meta_preview_container<Ms: 'static>() -> Node<Ms> {
+    div![
+        class![
+            "meta-preview",
+            "meta-preview-container",
+        ],
+        view_meta_info_container(),
+        view_action_buttons_container(),
+    ]
+}
+
+fn view_meta_info_container<Ms: 'static>() -> Node<Ms> {
+    div![
+        class![
+            "meta-info-container",
+        ],
+        img![
+            class![
+                "logo",
+            ],
+            attrs!{
+                At::Src => "https://images.metahub.space/logo/medium/tt0320691/img",
+                At::Alt => " ",
+            }
+        ],
+        div![
+            class![
+                "runtime-release-info-container",
+            ],
+            div![
+                class![
+                    "release-info-label"
+                ],
+                "2003"
+            ]
+        ],
+        div![
+            class![
+                "name-container"
+            ],
+            "Underworld"
+        ],
+        div![
+            class![
+                "description-container",
+            ],
+            "Selene, a vampire warrior, is entrenched in a conflict between vampires and werewolves, while falling in love with Michael, a human who is sought by werewolves for unknown reasons."
+        ],
+        view_meta_links_containers(),
+    ]
+}
+
+// ------ view meta links containers ------
+
+fn view_meta_links_containers<Ms: 'static>() -> Vec<Node<Ms>> {
+    vec![
+        div![
+            class![
+                "meta-links",
+                "meta-links-container"
+            ],
+            div![
+                class![
+                    "label-container",
+                ],
+                "Genres:"
+            ],
+            div![
+                class![
+                    "links-container"
+                ],
+                view_genres(),
+            ]
+        ],
+        div![
+            class![
+                "meta-links",
+                "meta-links-container"
+            ],
+            div![
+                class![
+                    "label-container",
+                ],
+                "Writers:"
+            ],
+            div![
+                class![
+                    "links-container"
+                ],
+                view_writers(),
+            ]
+        ],
+        div![
+            class![
+                "meta-links",
+                "meta-links-container"
+            ],
+            div![
+                class![
+                    "label-container",
+                ],
+                "Directors:"
+            ],
+            div![
+                class![
+                    "links-container"
+                ],
+                view_directors(),
+            ]
+        ],
+        div![
+            class![
+                "meta-links",
+                "meta-links-container"
+            ],
+            div![
+                class![
+                    "label-container",
+                ],
+                "Cast:"
+            ],
+            div![
+                class![
+                    "links-container"
+                ],
+                view_cast(),
+            ]
+        ],
+    ]
+}
+
+fn view_genres<Ms: 'static>() -> Vec<Node<Ms>> {
+    vec![
+        a![
+            class![
+                "link-container",
+                "button-container",
+            ],
+            attrs!{
+                At::TabIndex => -1,
+                At::Title => "Action",
+                At::Href => "#/discover/xxx/yyy/?genre=Action"
+            },
+            "Action, "
+        ],
+        a![
+            class![
+                "link-container",
+                "button-container",
+            ],
+            attrs!{
+                At::TabIndex => -1,
+                At::Title => "Fantasy",
+                At::Href => "#/discover/xxx/yyy/?genre=Fantasy"
+            },
+            "Fantasy, "
+        ],
+        a![
+            class![
+                "link-container",
+                "button-container",
+            ],
+            attrs!{
+                At::TabIndex => -1,
+                At::Title => "Thriller",
+                At::Href => "#/discover/xxx/yyy/?genre=Thriller"
+            },
+            "Thriller",
+        ],
+    ]
+}
+
+fn view_writers<Ms: 'static>() -> Vec<Node<Ms>> {
+    vec![
+        a![
+            class![
+                "link-container",
+                "button-container",
+            ],
+            attrs!{
+                At::TabIndex => -1,
+                At::Title => "Kevin Grevioux",
+                At::Href => "#/search?q=Kevin Grevioux"
+            },
+            "Kevin Grevioux, "
+        ],
+        a![
+            class![
+                "link-container",
+                "button-container",
+            ],
+            attrs!{
+                At::TabIndex => -1,
+                At::Title => "Len Wiseman",
+                At::Href => "#/search?q=Len Wiseman"
+            },
+            "Len Wiseman, "
+        ],
+        a![
+            class![
+                "link-container",
+                "button-container",
+            ],
+            attrs!{
+                At::TabIndex => -1,
+                At::Title => "Danny McBride",
+                At::Href => "#/search?q=Danny McBride"
+            },
+            "Danny McBride"
+        ],
+    ]
+}
+
+fn view_directors<Ms: 'static>() -> Vec<Node<Ms>> {
+    vec![
+        a![
+            class![
+                "link-container",
+                "button-container",
+            ],
+            attrs!{
+                At::TabIndex => -1,
+                At::Title => "Len Wiseman",
+                At::Href => "#/search?q=Len Wiseman"
+            },
+            "Len Wiseman"
+        ],
+    ]
+}
+
+fn view_cast<Ms: 'static>() -> Vec<Node<Ms>> {
+    vec![
+        a![
+            class![
+                "link-container",
+                "button-container",
+            ],
+            attrs!{
+                At::TabIndex => -1,
+                At::Title => "Kate Beckinsale",
+                At::Href => "#/search?q=Kate Beckinsale"
+            },
+            "Kate Beckinsale, "
+        ],
+        a![
+            class![
+                "link-container",
+                "button-container",
+            ],
+            attrs!{
+                At::TabIndex => -1,
+                At::Title => "Scott Speedman",
+                At::Href => "#/search?q=Scott Speedman"
+            },
+            "Scott Speedman, "
+        ],
+        a![
+            class![
+                "link-container",
+                "button-container",
+            ],
+            attrs!{
+                At::TabIndex => -1,
+                At::Title => "Michael Sheen",
+                At::Href => "#/search?q=Michael Sheen"
+            },
+            "Michael Sheen, "
+        ],
+        a![
+            class![
+                "link-container",
+                "button-container",
+            ],
+            attrs!{
+                At::TabIndex => -1,
+                At::Title => "Shane Brolly",
+                At::Href => "#/search?q=Shane Brolly"
+            },
+            "Shane Brolly"
+        ],
+    ]
+}
+
+// ------ view action buttons container ------
+
+fn view_action_buttons_container<Ms: 'static>() -> Node<Ms> {
+    div![
+        class![
+            "action-buttons-container",
+        ],
+        view_action_button_add_to_library(),
+        view_action_button_trailer(),
+        view_action_button_imdb(),
+        view_action_button_share(),
+    ]
+}
+
+fn view_action_button_add_to_library<Ms: 'static>() -> Node<Ms> {
+    div![
+        class![
+            "meta-preview-action-button",
+            "action-button-container",
+            "button-container",
+        ],
+        attrs!{
+            At::TabIndex => -1,
+            At::Title => "Add to library"
+        },
+        div![
+            class![
+                "icon-container",
+            ],
+            svg![
+                class!["icon",],
+                attrs! {
+                    At::ViewBox => "0 0 1264 1024",
+                    "icon" => "ic_addlib",
+                },
+                path![attrs! {
+                    At::D => "M78.306 0c-43.178 0.17-78.135 35.127-78.306 78.29l-0 0.016v764.988c2.636 41.27 36.754 73.744 78.456 73.744s75.82-32.474 78.445-73.514l0.012-0.23v-764.988c-0.171-43.284-35.299-78.306-78.606-78.306-0 0-0 0-0.001 0l0 0z"
+                }],
+                path![attrs! {
+                    At::D => "M341.835 153.901c-43.178 0.17-78.135 35.127-78.306 78.29l-0 0.016v611.087c0 43.663 35.396 79.059 79.059 79.059s79.059-35.396 79.059-79.059v0-611.087c-0.166-43.288-35.296-78.315-78.607-78.315-0.424 0-0.847 0.003-1.269 0.010l0.064-0.001z"
+                }],
+                path![attrs! {
+                    At::D => "M963.765 421.647c-166.335 0-301.176 134.841-301.176 301.176s134.841 301.176 301.176 301.176c166.335 0 301.176-134.841 301.176-301.176v0c0-166.335-134.841-301.176-301.176-301.176v0zM1156.518 768.602h-148.179v147.275h-90.353v-148.179h-147.878v-90.353h147.275v-147.878h90.353v147.275h147.275z"
+                }],
+                path![attrs! {
+                    At::D => "M683.972 465.016v-386.711c-2.636-41.27-36.754-73.744-78.456-73.744s-75.82 32.474-78.445 73.514l-0.012 0.23v764.988c-0 0-0 0-0 0.001 0 43.247 35.059 78.306 78.306 78.306 0.106 0 0.212-0 0.318-0.001l-0.016 0c0.068 0 0.147 0 0.227 0 10.82 0 21.097-2.329 30.355-6.513l-0.465 0.188c-32.753-54.79-52.119-120.857-52.119-191.447 0-99.528 38.499-190.064 101.417-257.529l-0.206 0.223z"
+                }],
+                path![attrs! {
+                    At::D => "M817.092 371.351c42.987-18.759 93.047-29.807 145.652-30.117l0.117-0.001h8.433l-60.235-262.325c-8.294-35.054-39.322-60.736-76.348-60.736-43.274 0-78.355 35.081-78.355 78.355 0 6.248 0.731 12.325 2.113 18.151l-0.106-0.532z"
+                }],
+            ],
+        ],
+        div![
+            class![
+                "label-container",
+            ],
+            div![
+                class![
+                    "label"
+                ],
+                "Add to library",
+            ]
+        ]
+    ]
+}
+
+fn view_action_button_trailer<Ms: 'static>() -> Node<Ms> {
+    a![
+        class![
+            "meta-preview-action-button",
+            "action-button-container",
+            "button-container",
+        ],
+        attrs!{
+            At::TabIndex => 0,
+            At::Title => "Trailer",
+            At::Href => "#/player?stream=mn4O3iQ8B_s",
+        },
+        div![
+            class![
+                "icon-container",
+            ],
+            svg![
+                class!["icon",],
+                attrs! {
+                    At::ViewBox => "0 0 840 1024",
+                    "icon" => "ic_movies",
+                },
+                path![attrs! {
+                    At::D => "M813.176 1024h-708.969c-14.3-3.367-24.781-16.017-24.781-31.115 0-0.815 0.031-1.623 0.090-2.422l-0.006 0.107q0-215.642 0-430.984v-4.819c0.015 0 0.033 0 0.051 0 30.976 0 58.991-12.673 79.146-33.116l0.013-0.013c19.218-19.773 31.069-46.796 31.069-76.586 0-1.134-0.017-2.265-0.051-3.391l0.004 0.165h649.939v558.381c-1.037 2.541-2.047 4.621-3.168 6.63l0.157-0.306c-4.8 8.938-13.235 15.394-23.273 17.431l-0.219 0.037zM796.612 481.882h-126.795c-1.944 0.438-3.547 1.646-4.5 3.28l-0.018 0.033-60.235 95.473c-0.466 0.866-0.972 1.957-1.422 3.076l-0.084 0.237h128.301c3.012 0 3.915 0 5.421-3.313l56.922-95.172c0.887-1.056 1.687-2.24 2.356-3.505l0.053-0.11zM393.638 583.078h128.602c0.156 0.017 0.337 0.026 0.52 0.026 2.3 0 4.246-1.517 4.892-3.604l0.010-0.036c18.974-30.118 37.948-62.645 56.621-94.268l2.711-4.518h-125.892c-0.179-0.018-0.387-0.028-0.597-0.028-2.519 0-4.694 1.473-5.711 3.604l-0.016 0.038-58.428 94.268zM377.675 481.882h-126.193c-0.024-0-0.052-0.001-0.080-0.001-2.57 0-4.763 1.609-5.629 3.875l-0.014 0.041-58.428 93.064-2.711 4.216h124.386c0.165 0.018 0.357 0.028 0.551 0.028 2.127 0 3.968-1.225 4.856-3.008l0.014-0.031 60.235-95.473z"
+                }],
+                path![attrs! {
+                    At::D => "M707.464 0c4.931 1.519 9.225 3.567 13.143 6.142l-0.192-0.119c4.632 3.831 8.386 8.548 11.033 13.909l0.11 0.247c18.372 44.574 36.442 90.353 54.814 134.325l-602.353 243.652c-18.275-41.26-58.864-69.523-106.054-69.523-14.706 0-28.77 2.745-41.71 7.75l0.79-0.269c-4.819-12.047-10.842-24.094-14.758-37.045-0.883-2.705-1.392-5.818-1.392-9.050 0-13.254 8.561-24.508 20.455-28.534l0.212-0.062c18.673-6.626 39.153-14.456 58.428-20.48l542.118-217.751 43.972-19.275 10.24-3.915zM123.181 271.059h1.807l93.064 67.464c0.846 0.357 1.829 0.565 2.861 0.565s2.015-0.208 2.911-0.583l-0.050 0.018 90.353-35.84 26.504-10.842-2.409-1.807-91.859-65.656c-0.846-0.572-1.889-0.914-3.012-0.914s-2.166 0.341-3.031 0.926l0.019-0.012-77.402 30.118zM535.793 214.739l-2.711-2.108-90.353-66.56c-0.933-0.622-2.080-0.993-3.313-0.993s-2.38 0.371-3.335 1.007l0.022-0.014-118.061 45.779 2.108 1.807 92.461 67.162c0.846 0.357 1.829 0.565 2.861 0.565s2.015-0.208 2.911-0.583l-0.050 0.018 87.341-34.635zM730.353 135.529h-1.807l-91.859-68.969c-0.803-0.547-1.794-0.874-2.861-0.874s-2.059 0.327-2.879 0.885l0.018-0.011-90.353 36.744c-8.433 3.012-16.565 6.325-24.998 9.939l2.409 2.108 90.353 65.355c0.846 0.357 1.829 0.565 2.861 0.565s2.015-0.208 2.911-0.583l-0.050 0.018 75.294-30.118z"
+                }],
+                path![attrs! {
+                    At::D => "M0 433.393c0-3.614 1.506-7.228 2.409-10.541 8.935-34.682 39.932-59.894 76.818-59.894 4.782 0 9.465 0.424 14.014 1.236l-0.48-0.071c37.902 5.909 66.564 38.317 66.564 77.421 0 2.432-0.111 4.839-0.328 7.214l0.023-0.305c-3.944 40.578-37.878 72.037-79.159 72.037-39.144 0-71.681-28.287-78.286-65.534l-0.070-0.48c-0.474-1.046-0.977-1.935-1.547-2.775l0.041 0.064z"
+                }],
+            ],
+        ],
+        div![
+            class![
+                "label-container",
+            ],
+            div![
+                class![
+                    "label"
+                ],
+                "Trailer",
+            ]
+        ]
+    ]
+}
+
+fn view_action_button_imdb<Ms: 'static>() -> Node<Ms> {
+    a![
+        class![
+            "meta-preview-action-button",
+            "action-button-container",
+            "button-container",
+        ],
+        attrs!{
+            At::TabIndex => 0,
+            At::Title => "7.0 / 10",
+            At::Href => "https://imdb.com/title/tt0320691",
+            At::Target => "_blank",
+        },
+        div![
+            class![
+                "icon-container",
+            ],
+            svg![
+                class!["icon",],
+                attrs! {
+                    At::ViewBox => "0 0 1762 1024",
+                    "icon" => "ic_imdb",
+                },
+                path![attrs! {
+                    At::D => "M1598.645 0h-1435.106c-90.32 0-163.539 73.219-163.539 163.539v0 696.922c0 90.32 73.219 163.539 163.539 163.539v0h1435.106c90.32 0 163.539-73.219 163.539-163.539h-0v-696.922c0-90.32-73.219-163.539-163.539-163.539h-0zM1650.146 860.461c-0.17 28.375-23.126 51.331-51.485 51.501l-0.016 0h-1435.106c-28.375-0.17-51.331-23.126-51.501-51.485l-0-0.016v-696.922c0.17-28.375 23.126-51.331 51.485-51.501l0.016-0h1435.106c28.375 0.17 51.331 23.126 51.501 51.485l0 0.016z"
+                }],
+                path![attrs! {
+                    At::D => "M246.965 267.445h89.449v458.391h-89.449v-458.391z"
+                }],
+                path![attrs! {
+                    At::D => "M606.268 576.452l-87.341-309.007h-113.845v458.391h78.607v-319.247l84.329 268.348h76.499l84.329-274.673v325.572h78.607v-458.391h-113.845l-87.341 309.007z"
+                }],
+                path![attrs! {
+                    At::D => "M1033.939 267.445h-150.588v458.391h150.588c3.777 0.267 8.184 0.419 12.627 0.419 46.147 0 88.459-16.422 121.41-43.742l-0.315 0.254c29.323-28.212 47.538-67.787 47.538-111.617 0-3.115-0.092-6.208-0.273-9.277l0.020 0.423v-130.409c0.139-2.475 0.219-5.372 0.219-8.286 0-43.945-18.065-83.671-47.175-112.157l-0.028-0.027c-32.988-27.57-75.855-44.31-122.631-44.31-4.008 0-7.987 0.123-11.934 0.365l0.541-0.027zM1126.701 564.104c0.085 1.316 0.134 2.853 0.134 4.401 0 21.296-9.21 40.441-23.863 53.67l-0.064 0.057c-16.699 12.886-37.923 20.654-60.961 20.654-2.076 0-4.137-0.063-6.181-0.187l0.281 0.014h-67.162v-291.84h67.162c1.905-0.131 4.13-0.206 6.371-0.206 22.889 0 43.96 7.785 60.709 20.851l-0.22-0.165c14.712 13.184 23.926 32.244 23.926 53.457 0 1.537-0.048 3.063-0.144 4.576l0.010-0.207z"
+                }],
+                path![attrs! {
+                    At::D => "M1436.311 393.939c-0.178-0.001-0.389-0.002-0.6-0.002-17.816 0-34.259 5.882-47.492 15.811l0.205-0.147c-11.386 9.029-20.763 20.040-27.727 32.576l-0.282 0.554v-175.285h-86.438v458.391h86.438v-43.068c6.124 13.388 15.135 24.523 26.291 32.975l0.213 0.155c13.088 9.255 29.376 14.794 46.957 14.794 0.857 0 1.71-0.013 2.56-0.039l-0.125 0.003c1.284 0.061 2.788 0.095 4.301 0.095 31.288 0 59.116-14.817 76.849-37.817l0.168-0.226c18.98-26.686 30.343-59.939 30.343-95.847 0-3.047-0.082-6.074-0.243-9.081l0.018 0.419v-51.501c0.143-2.602 0.224-5.648 0.224-8.712 0-36.189-11.357-69.725-30.701-97.238l0.359 0.539c-17.796-22.891-45.337-37.477-76.284-37.477-1.77 0-3.53 0.048-5.277 0.142l0.243-0.010zM1459.802 589.101c0.060 1.075 0.094 2.332 0.094 3.598 0 15.836-5.361 30.42-14.366 42.037l0.117-0.157c-8.604 9.843-21.183 16.026-35.206 16.026-0.859 0-1.712-0.023-2.559-0.069l0.118 0.005c-0.398 0.010-0.865 0.016-1.335 0.016-9.083 0-17.645-2.234-25.165-6.182l0.297 0.142c-7.292-3.783-13.028-9.713-16.469-16.945l-0.095-0.222c-3.627-7.519-5.747-16.351-5.747-25.678 0-0.608 0.009-1.214 0.027-1.818l-0.002 0.089v-73.487c-0.022-0.631-0.035-1.371-0.035-2.115 0-9.607 2.122-18.718 5.922-26.89l-0.164 0.394c3.604-7.587 9.311-13.682 16.368-17.667l0.197-0.102c7.223-3.806 15.784-6.040 24.868-6.040 0.469 0 0.937 0.006 1.404 0.018l-0.069-0.001c0.743-0.043 1.612-0.068 2.488-0.068 14.131 0 26.756 6.445 35.097 16.555l0.062 0.077c8.389 11.489 13.422 25.892 13.422 41.471 0 1.728-0.062 3.441-0.184 5.138l0.013-0.228z"
+                }],
+            ],
+        ],
+        div![
+            class![
+                "label-container",
+            ],
+            div![
+                class![
+                    "label"
+                ],
+                "7.0 / 10",
+            ]
+        ]
+    ]
+}
+
+fn view_action_button_share<Ms: 'static>() -> Node<Ms> {
+    div![
+        class![
+            "meta-preview-action-button",
+            "action-button-container",
+            "button-container",
+        ],
+        attrs!{
+            At::TabIndex => -1,
+            At::Title => "Share"
+        },
+        div![
+            class![
+                "icon-container",
+            ],
+            svg![
+                class!["icon",],
+                attrs! {
+                    At::ViewBox => "0 0 1024 1024",
+                    "icon" => "ic_share",
+                },
+                path![attrs! {
+                    At::D => "M846.005 679.454c-62.726 0.19-117.909 32.308-150.171 80.95l-0.417 0.669-295.755-96.979c2.298-11.196 3.614-24.064 3.614-37.239 0-0.038-0-0.075-0-0.113l0 0.006c0-0.039 0-0.085 0-0.132 0-29.541-6.893-57.472-19.159-82.272l0.486 1.086 221.967-143.059c42.092 37.259 97.727 60.066 158.685 60.235l0.035 0c0.81 0.010 1.768 0.016 2.726 0.016 128.794 0 233.38-103.646 234.901-232.079l0.001-0.144c0-131.737-106.794-238.532-238.532-238.532s-238.532 106.794-238.532 238.532h0c0.012 33.532 7.447 65.325 20.752 93.828l-0.573-1.367-227.087 146.372c-32.873-23.074-73.687-36.92-117.729-37.045l-0.031-0c-0.905-0.015-1.974-0.023-3.044-0.023-108.186 0-196.124 86.69-198.139 194.395l-0.003 0.189c2.017 107.893 89.956 194.583 198.142 194.583 1.070 0 2.139-0.008 3.205-0.025l-0.161 0.002c0.108 0 0.235 0 0.363 0 60.485 0 114.818-26.336 152.159-68.168l0.175-0.2 313.826 103.002c-0.004 0.448-0.006 0.976-0.006 1.506 0 98.47 79.826 178.296 178.296 178.296s178.296-79.826 178.296-178.296c0-98.468-79.823-178.293-178.29-178.296l-0-0zM923.106 851.727c0.054 1.079 0.084 2.343 0.084 3.614 0 42.748-34.654 77.402-77.402 77.402s-77.402-34.654-77.402-77.402c0-42.748 34.654-77.402 77.402-77.402 0.076 0 0.152 0 0.229 0l-0.012-0c0.455-0.010 0.99-0.015 1.527-0.015 41.12 0 74.572 32.831 75.572 73.711l0.002 0.093zM626.748 230.4c3.537-73.358 63.873-131.495 137.788-131.495s134.251 58.137 137.776 131.179l0.012 0.316c-3.537 73.358-63.873 131.495-137.788 131.495s-134.251-58.137-137.776-131.179l-0.012-0.316zM301.176 626.748c-1.34 53.35-44.907 96.087-98.456 96.087-0.54 0-1.078-0.004-1.616-0.013l0.081 0.001c-1.607 0.096-3.486 0.151-5.377 0.151-53.061 0-96.075-43.014-96.075-96.075s43.014-96.075 96.075-96.075c1.892 0 3.77 0.055 5.635 0.162l-0.258-0.012c0.459-0.008 1-0.012 1.543-0.012 53.443 0 96.943 42.568 98.445 95.648l0.003 0.139z"
+                }],
+            ],
+        ],
+        div![
+            class![
+                "label-container",
+            ],
+            div![
+                class![
+                    "label"
+                ],
+                "Share",
+            ]
+        ]
+    ]
+}
+
+// ------ view streams list ------
+
+fn view_streams_list_container<Ms: 'static>() -> Node<Ms> {
+    div![
+        class![
+            "streams-list",
+            "streams-list-container",
+        ],
+        div![
+            class![
+                "streams-scroll-container",
+            ],
+            // stream
+            div![
+                class![
+                    "stream",
+                    "stream-container",
+                    "button-container",
+                ],
+                attrs!{
+                    At::TabIndex => 0,
+                    At::Title => "Google Sample Videos",
+                },
+                div![
+                    class![
+                        "stream-addon-container",
+                    ],
+                    div![
+                        class![
+                            "addon-name",
+                        ],
+                        "Google",
+                    ]
+                ],
+                div![
+                    class![
+                        "info-container",
+                    ],
+                    div![
+                        class![
+                            "description-label",
+                        ],
+                        "Google sample videos",
+                    ]
+                ],
+                div![
+                    class![
+                        "play-icon-container",
+                    ],
+                    svg![
+                        class!["play-icon",],
+                        attrs! {
+                            At::ViewBox => "0 0 899 1024",
+                            "icon" => "ic_play",
+                        },
+                        path![attrs! {
+                            At::D => "M891.482 512l-884.254 512v-1024z"
+                        }],
+                    ],
+                ],
+            ],
+            // stream
+            div![
+                class![
+                    "stream",
+                    "stream-container",
+                    "button-container",
+                ],
+                attrs!{
+                    At::TabIndex => 0,
+                    At::Title => "Stremio demo videos",
+                },
+                div![
+                    class![
+                        "stream-addon-container",
+                    ],
+                    div![
+                        class![
+                            "addon-name",
+                        ],
+                        "Stremio",
+                    ]
+                ],
+                div![
+                    class![
+                        "info-container",
+                    ],
+                    div![
+                        class![
+                            "description-label",
+                        ],
+                        "Stremio demo videos",
+                    ]
+                ],
+                div![
+                    class![
+                        "play-icon-container",
+                    ],
+                    svg![
+                        class!["play-icon",],
+                        attrs! {
+                            At::ViewBox => "0 0 899 1024",
+                            "icon" => "ic_play",
+                        },
+                        path![attrs! {
+                            At::D => "M891.482 512l-884.254 512v-1024z"
+                        }],
+                    ],
+                ],
+                div![
+                    class![
+                        "progress-bar-container",
+                    ],
+                    div![
+                        class![
+                            "progress-bar",
+                        ],
+                        style!{
+                            St::Width => unit!(30, %),
+                        }
+                    ]
+                ]
+            ],
+        ],
+        view_install_addons_button(),
+    ]
+}
+
+fn view_install_addons_button<Ms: 'static>() -> Node<Ms> {
+    a![
+        class![
+            "install-addons-container",
+            "button-container",
+        ],
+        attrs!{
+            At::TabIndex => 0,
+            At::Title => "Install addons",
+            At::Href => "#/addons",
+        },
+        svg![
+            class!["icon",],
+            attrs! {
+                At::ViewBox => "0 0 1043 1024",
+                "icon" => "ic_addons",
+            },
+            path![attrs! {
+                At::D => "M145.468 679.454c-40.056-39.454-80.715-78.908-120.471-118.664-33.431-33.129-33.129-60.235 0-90.353l132.216-129.807c5.693-5.938 12.009-11.201 18.865-15.709l0.411-0.253c23.492-15.059 41.864-7.529 48.188 18.974 0 7.228 2.711 14.758 3.614 22.287 3.801 47.788 37.399 86.785 82.050 98.612l0.773 0.174c10.296 3.123 22.128 4.92 34.381 4.92 36.485 0 69.247-15.94 91.702-41.236l0.11-0.126c24.858-21.654 40.48-53.361 40.48-88.718 0-13.746-2.361-26.941-6.701-39.201l0.254 0.822c-14.354-43.689-53.204-75.339-99.907-78.885l-0.385-0.023c-18.372-2.409-41.562 0-48.188-23.492s11.445-34.635 24.998-47.887q65.054-62.946 130.409-126.795c32.527-31.925 60.235-32.226 90.353 0 40.659 39.153 80.715 78.908 120.471 118.362 8.348 8.594 17.297 16.493 26.82 23.671l0.587 0.424c8.609 7.946 20.158 12.819 32.846 12.819 24.823 0 45.29-18.653 48.148-42.707l0.022-0.229c3.012-13.252 4.518-26.805 8.734-39.755 12.103-42.212 50.358-72.582 95.705-72.582 3.844 0 7.637 0.218 11.368 0.643l-0.456-0.042c54.982 6.832 98.119 49.867 105.048 104.211l0.062 0.598c0.139 1.948 0.218 4.221 0.218 6.512 0 45.084-30.574 83.026-72.118 94.226l-0.683 0.157c-12.348 3.915-25.299 5.722-37.948 8.433-45.779 9.638-60.235 46.984-30.118 82.824 15.265 17.569 30.806 33.587 47.177 48.718l0.409 0.373c31.925 31.925 64.452 62.946 96.075 94.871 13.698 9.715 22.53 25.511 22.53 43.369s-8.832 33.655-22.366 43.259l-0.164 0.111c-45.176 45.176-90.353 90.353-137.035 134.325-5.672 5.996-12.106 11.184-19.169 15.434l-0.408 0.227c-4.663 3.903-10.725 6.273-17.341 6.273-13.891 0-25.341-10.449-26.92-23.915l-0.012-0.127c-2.019-7.447-3.714-16.45-4.742-25.655l-0.077-0.848c-4.119-47.717-38.088-86.476-82.967-97.721l-0.76-0.161c-9.584-2.63-20.589-4.141-31.947-4.141-39.149 0-74.105 17.956-97.080 46.081l-0.178 0.225c-21.801 21.801-35.285 51.918-35.285 85.185 0 1.182 0.017 2.36 0.051 3.533l-0.004-0.172c1.534 53.671 40.587 97.786 91.776 107.115l0.685 0.104c12.649 2.409 25.901 3.313 38.249 6.626 22.588 6.325 30.118 21.685 18.372 41.864-4.976 8.015-10.653 14.937-17.116 21.035l-0.051 0.047c-44.875 44.574-90.353 90.353-135.228 133.12-10.241 14.067-26.653 23.106-45.176 23.106s-34.935-9.039-45.066-22.946l-0.111-0.159c-40.659-38.852-80.414-78.908-120.471-118.362z"
+            }],
+        ],
+        div![
+            class![
+                "label",
+            ],
+            "Install addons",
+        ]
+    ]
+}
+
+// ------ view videos list ------
+
+fn view_videos_list_container<Ms: 'static>() -> Node<Ms> {
+    div![
+        class![
+            "videos-list",
+            "videos-list-container",
+        ],
+        view_season_bar_container(),
+        view_video_scroll_container(),
+    ]
+}
+
+fn view_season_bar_container<Ms: 'static>() -> Node<Ms> {
+    div![
+        class![
+            "seasons-bar",
+            "seasons-bar-container",
+        ],
+        div![
+            class![
+                "prev-season-button",
+                "button-container",
+            ],
+            attrs!{
+                At::TabIndex => 0,
+            },
+            svg![
+                class!["icon",],
+                attrs! {
+                    At::ViewBox => "0 0 606 1024",
+                    "icon" => "ic_arrow_left",
+                },
+                path![attrs! {
+                    At::D => "M264.132 512l309.609-319.247c19.848-20.685 32.069-48.821 32.069-79.812s-12.221-59.127-32.107-79.852l0.038 0.040c-19.51-20.447-46.972-33.16-77.402-33.16s-57.892 12.713-77.363 33.118l-0.040 0.042-387.012 399.059c-19.713 20.744-31.839 48.862-31.839 79.812s12.126 59.067 31.886 79.861l-0.047-0.050 387.012 399.059c19.51 20.447 46.972 33.16 77.402 33.16s57.892-12.713 77.363-33.118l0.040-0.042c19.848-20.685 32.069-48.821 32.069-79.812s-12.221-59.127-32.107-79.852l0.038 0.040z"
+                }],
+            ],
+        ],
+        div![
+            class![
+                "seasons-popup-label-container",
+                "button-container",
+            ],
+            attrs!{
+                At::TabIndex => 0,
+                At::Title => "Season 1",
+            },
+            div![
+                class![
+                    "season-label"
+                ],
+                "Season",
+            ],
+            div![
+                class![
+                    "number-label",
+                ],
+                "1",
+            ]
+        ],
+        div![
+            class![
+                "next-season-button",
+                "button-container",
+            ],
+            attrs!{
+                At::TabIndex => 0,
+            },
+            svg![
+                class!["icon",],
+                attrs! {
+                    At::ViewBox => "0 0 606 1024",
+                    "icon" => "ic_arrow_right",
+                },
+                path![attrs! {
+                    At::D => "M341.534 512l-309.609-319.247c-19.713-20.744-31.839-48.862-31.839-79.812s12.126-59.067 31.886-79.861l-0.047 0.050c19.51-20.447 46.972-33.16 77.402-33.16s57.892 12.713 77.363 33.118l0.040 0.042 387.012 399.059c19.848 20.685 32.069 48.821 32.069 79.812s-12.221 59.127-32.107 79.852l0.038-0.040-387.012 399.059c-19.51 20.447-46.972 33.16-77.402 33.16s-57.892-12.713-77.363-33.118l-0.040-0.042c-19.713-20.744-31.839-48.862-31.839-79.812s12.126-59.067 31.886-79.861l-0.047 0.050z"
+                }],
+            ],
+        ],
+    ]
+}
+
+fn view_video_scroll_container<Ms: 'static>() -> Node<Ms> {
+    div![
+        class![
+            "videos-scroll-container",
+        ],
+        div![
+            class![
+                "video",
+                "video-container",
+                "button-container",
+            ],
+            attrs!{
+                At::TabIndex => 0,
+                At::Title => "How to create a Stremio add-on with Node.js",
+            },
+            div![
+                class![
+                    "poster-container",
+                ],
+                img![
+                    class![
+                        "poster",
+                    ],
+                    attrs!{
+                        At::Src => "https://theme.zdassets.com/theme_assets/2160011/77a6ad5aee11a07eb9b87281070f1aadf946f2b3.png",
+                        At::Alt => " ",
+                    }
+                ]
+            ],
+            div![
+                class![
+                    "info-container",
+                ],
+                div![
+                    class![
+                        "name-container",
+                    ],
+                    "1. How to create a Stremio add-on with Node.js",
+                ],
+                div![
+                    class![
+                        "released-container",
+                    ],
+                    "Jun 30, 19",
+                ]
+            ],
+            div![
+                class![
+                    "next-icon-container",
+                ],
+                svg![
+                    class!["next-icon",],
+                    attrs! {
+                        At::ViewBox => "0 0 565 1024",
+                        "icon" => "ic_arrow_thin_right",
+                    },
+                    path![attrs! {
+                        At::D => "M84.932 14.155l465.016 463.511c8.963 8.73 14.578 20.859 14.757 34.301l0 0.033c-0.021 13.598-5.67 25.873-14.743 34.621l-0.015 0.014-464.113 463.209c-9.052 8.82-21.434 14.26-35.087 14.26s-26.035-5.44-35.098-14.27l0.011 0.010c-9.355-8.799-15.292-21.14-15.66-34.87l-0.001-0.066c-0.001-0.103-0.001-0.225-0.001-0.348 0-13.437 5.534-25.582 14.448-34.278l0.010-0.009 430.080-428.273-429.779-427.972c-9.101-8.684-14.76-20.907-14.76-34.451 0-0.171 0.001-0.341 0.003-0.511l-0 0.026c-0-0.043-0-0.094-0-0.145 0-13.595 5.526-25.899 14.455-34.789l0.002-0.002c9.099-8.838 21.532-14.287 35.238-14.287s26.138 5.449 35.25 14.299l-0.012-0.012z"
+                    }],
+                ],
+            ],
+        ]
+    ]
 }

--- a/src/page/discover.rs
+++ b/src/page/discover.rs
@@ -1,8 +1,8 @@
-use crate::{entity::multi_select, route::Route, SharedModel, GMsg};
+use crate::{entity::multi_select, route::Route, GMsg, SharedModel};
 use seed::{prelude::*, *};
 use std::rc::Rc;
 use stremio_core::state_types::{
-    Action, ActionLoad, CatalogEntry, CatalogError, Loadable, Msg as CoreMsg, TypeEntry, Internal
+    Action, ActionLoad, CatalogEntry, CatalogError, Internal, Loadable, Msg as CoreMsg, TypeEntry,
 };
 use stremio_core::types::MetaPreview;
 use stremio_core::types::{
@@ -89,15 +89,15 @@ pub fn sink(g_msg: GMsg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>)
         GMsg::GoTo(Route::Discover(resource_request)) => {
             load_catalog(resource_request, orders);
             return None;
-        },
+        }
         GMsg::Core(ref core_msg) => {
             if let CoreMsg::Internal(Internal::AddonResponse(_, result)) = core_msg.as_ref() {
                 if let Ok(ResourceResponse::Metas { metas }) = result.as_ref() {
                     model.selected_meta_preview_id = metas.first().map(|meta| meta.id.clone());
                 }
             }
-        },
-        _ => ()
+        }
+        _ => (),
     }
     Some(g_msg)
 }
@@ -106,7 +106,8 @@ pub fn sink(g_msg: GMsg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>)
 //    Update
 // ------ ------
 
-#[allow(clippy::pub_enum_variant_names)]
+// @TODO box large fields?
+#[allow(clippy::pub_enum_variant_names, clippy::large_enum_variant)]
 #[derive(Clone)]
 pub enum Msg {
     MetaPreviewClicked(MetaPreview),
@@ -125,7 +126,11 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) 
         Msg::MetaPreviewClicked(meta_preview) => {
             if model.selected_meta_preview_id.as_ref() == Some(&meta_preview.id) {
                 let detail_route = Route::Detail {
-                    video_id: if meta_preview.type_name == "movie" { Some(meta_preview.id.clone()) } else { None },
+                    video_id: if meta_preview.type_name == "movie" {
+                        Some(meta_preview.id.clone())
+                    } else {
+                        None
+                    },
                     type_name: meta_preview.type_name,
                     id: meta_preview.id,
                 };
@@ -150,7 +155,7 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) 
         }
         Msg::TypeSelectorChanged(groups_with_selected_items) => {
             let req = type_selector::resource_request(groups_with_selected_items);
-            orders.send_g_msg(GMsg::GoTo(Route::Discover(Some(req.clone()))));
+            orders.send_g_msg(GMsg::GoTo(Route::Discover(Some(req))));
         }
 
         // ------ CatalogSelector  ------
@@ -168,7 +173,7 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) 
         }
         Msg::CatalogSelectorChanged(groups_with_selected_items) => {
             let req = catalog_selector::resource_request(groups_with_selected_items);
-            orders.send_g_msg(GMsg::GoTo(Route::Discover(Some(req.clone()))));
+            orders.send_g_msg(GMsg::GoTo(Route::Discover(Some(req))));
         }
 
         // ------ ExtraPropSelector  ------
@@ -188,7 +193,7 @@ pub fn update(msg: Msg, model: &mut Model, orders: &mut impl Orders<Msg, GMsg>) 
             if let Some(req) =
                 extra_prop_selector::resource_request(groups_with_selected_items, &catalog.selected)
             {
-                orders.send_g_msg(GMsg::GoTo(Route::Discover(Some(req.clone()))));
+                orders.send_g_msg(GMsg::GoTo(Route::Discover(Some(req))));
             }
         }
     }

--- a/src/page/discover/catalog_selector.rs
+++ b/src/page/discover/catalog_selector.rs
@@ -1,4 +1,4 @@
-use crate::entity::multi_select;
+use crate::{entity::multi_select, GMsg};
 use itertools::Itertools;
 use seed::prelude::*;
 use std::fmt::Debug;
@@ -29,7 +29,7 @@ pub struct Msg(multi_select::Msg);
 pub fn update<T: 'static + Debug, ParentMsg>(
     msg: Msg,
     model: &mut Model,
-    orders: &mut impl Orders<Msg>,
+    orders: &mut impl Orders<Msg, GMsg>,
     groups: Vec<multi_select::Group<T>>,
     on_change: impl FnOnce(Vec<multi_select::Group<T>>) -> ParentMsg,
 ) -> Option<ParentMsg> {

--- a/src/page/discover/extra_prop_selector.rs
+++ b/src/page/discover/extra_prop_selector.rs
@@ -1,4 +1,4 @@
-use crate::{entity::multi_select, GMsg, page::discover::ExtraPropOption};
+use crate::{entity::multi_select, page::discover::ExtraPropOption, GMsg};
 use seed::prelude::*;
 use std::fmt::Debug;
 use stremio_core::types::addons::{ManifestExtraProp, ResourceRequest};

--- a/src/page/discover/extra_prop_selector.rs
+++ b/src/page/discover/extra_prop_selector.rs
@@ -1,5 +1,4 @@
-use crate::entity::multi_select;
-use crate::page::discover::ExtraPropOption;
+use crate::{entity::multi_select, GMsg, page::discover::ExtraPropOption};
 use seed::prelude::*;
 use std::fmt::Debug;
 use stremio_core::types::addons::{ManifestExtraProp, ResourceRequest};
@@ -28,7 +27,7 @@ pub struct Msg(multi_select::Msg);
 pub fn update<T: 'static + Debug, ParentMsg>(
     msg: Msg,
     model: &mut Model,
-    orders: &mut impl Orders<Msg>,
+    orders: &mut impl Orders<Msg, GMsg>,
     groups: Vec<multi_select::Group<T>>,
     on_change: impl FnOnce(Vec<multi_select::Group<T>>) -> ParentMsg,
 ) -> Option<ParentMsg> {

--- a/src/page/discover/type_selector.rs
+++ b/src/page/discover/type_selector.rs
@@ -1,4 +1,4 @@
-use crate::entity::multi_select;
+use crate::{entity::multi_select, GMsg};
 use seed::prelude::*;
 use std::fmt::Debug;
 use stremio_core::state_types::TypeEntry;
@@ -28,7 +28,7 @@ pub struct Msg(multi_select::Msg);
 pub fn update<T: 'static + Debug, ParentMsg>(
     msg: Msg,
     model: &mut Model,
-    orders: &mut impl Orders<Msg>,
+    orders: &mut impl Orders<Msg, GMsg>,
     groups: Vec<multi_select::Group<T>>,
     on_change: impl FnOnce(Vec<multi_select::Group<T>>) -> ParentMsg,
 ) -> Option<ParentMsg> {

--- a/src/route.rs
+++ b/src/route.rs
@@ -1,14 +1,6 @@
 use seed::{prelude::*, *};
 use std::str::FromStr;
 use stremio_core::types::addons::{ParseResourceErr, ResourceRef, ResourceRequest};
-use crate::GMsg;
-use std::convert::TryFrom;
-
-pub fn go_to<Ms: 'static>(route: Route, orders: &mut impl Orders<Ms, GMsg>) {
-    let url = Url::try_from(route.to_href()).expect("`Url` from `Route`");
-    seed::push_route(url);
-    orders.send_g_msg(GMsg::RoutePushed(route));
-}
 
 // ------ Route ------
 

--- a/src/route.rs
+++ b/src/route.rs
@@ -8,7 +8,11 @@ use stremio_core::types::addons::{ParseResourceErr, ResourceRef, ResourceRequest
 pub enum Route {
     Board,
     Discover(Option<ResourceRequest>),
-    Detail { type_name: String, id: String, video_id: Option<String> },
+    Detail {
+        type_name: String,
+        id: String,
+        video_id: Option<String>,
+    },
     Player,
     Addons(Option<ResourceRequest>),
     NotFound,
@@ -19,7 +23,16 @@ impl Route {
         match self {
             Self::Board => "#/board".into(),
             Self::Discover(req) => format!("#/discover{}", resource_request_to_url_path(req)),
-            Self::Detail { type_name, id, video_id } => format!("#/detail/{}/{}/{}", type_name, id, video_id.as_ref().map(String::as_str).unwrap_or_default()),
+            Self::Detail {
+                type_name,
+                id,
+                video_id,
+            } => format!(
+                "#/detail/{}/{}/{}",
+                type_name,
+                id,
+                video_id.as_ref().map(String::as_str).unwrap_or_default()
+            ),
             Self::Player => "#/player".into(),
             Self::Addons(req) => format!("#/addons{}", resource_request_to_url_path(req)),
             Self::NotFound => "#/404".into(),
@@ -83,8 +96,12 @@ impl From<Url> for Route {
 
                 let video_id = hash.next().map(ToOwned::to_owned);
 
-                Self::Detail { type_name, id, video_id }
-            },
+                Self::Detail {
+                    type_name,
+                    id,
+                    video_id,
+                }
+            }
             Some("player") => Self::Player,
             Some("addons") => {
                 let encoded_base = if let Some(base) = hash.next() {

--- a/src/route.rs
+++ b/src/route.rs
@@ -8,7 +8,7 @@ use stremio_core::types::addons::{ParseResourceErr, ResourceRef, ResourceRequest
 pub enum Route {
     Board,
     Discover(Option<ResourceRequest>),
-    Detail,
+    Detail { type_name: String, id: String, video_id: Option<String> },
     Player,
     Addons(Option<ResourceRequest>),
     NotFound,
@@ -19,7 +19,7 @@ impl Route {
         match self {
             Self::Board => "#/board".into(),
             Self::Discover(req) => format!("#/discover{}", resource_request_to_url_path(req)),
-            Self::Detail => format!("#/detail/{}", "TODO"),
+            Self::Detail { type_name, id, video_id } => format!("#/detail/{}/{}/{}", type_name, id, video_id.as_ref().map(String::as_str).unwrap_or_default()),
             Self::Player => "#/player".into(),
             Self::Addons(req) => format!("#/addons{}", resource_request_to_url_path(req)),
             Self::NotFound => "#/404".into(),
@@ -66,7 +66,25 @@ impl From<Url> for Route {
 
                 Self::Discover(Some(req))
             }
-            Some("detail") => Self::Detail,
+            Some("detail") => {
+                let type_name = if let Some(type_name) = hash.next() {
+                    type_name.to_owned()
+                } else {
+                    error!("cannot find detail type_name");
+                    return Self::NotFound;
+                };
+
+                let id = if let Some(id) = hash.next() {
+                    id.to_owned()
+                } else {
+                    error!("cannot find detail id");
+                    return Self::NotFound;
+                };
+
+                let video_id = hash.next().map(ToOwned::to_owned);
+
+                Self::Detail { type_name, id, video_id }
+            },
             Some("player") => Self::Player,
             Some("addons") => {
                 let encoded_base = if let Some(base) = hash.next() {

--- a/src/route.rs
+++ b/src/route.rs
@@ -1,6 +1,14 @@
 use seed::{prelude::*, *};
 use std::str::FromStr;
 use stremio_core::types::addons::{ParseResourceErr, ResourceRef, ResourceRequest};
+use crate::GMsg;
+use std::convert::TryFrom;
+
+pub fn go_to<Ms: 'static>(route: Route, orders: &mut impl Orders<Ms, GMsg>) {
+    let url = Url::try_from(route.to_href()).expect("`Url` from `Route`");
+    seed::push_route(url);
+    orders.send_g_msg(GMsg::RoutePushed(route));
+}
 
 // ------ Route ------
 


### PR DESCRIPTION
Changes
- Hardcoded Detail page + routing:
  - Demo: https://stremio-seed-poc.netlify.com/#/discover => click the first item or double-click other items.
  - Only button `Install addons` works.
  - Design is rewritten from `stremio-web`.
  - Hardcoded video list in sidebar is also implemented.
  - It will be integrated with BE / Core once `stremio-core`'s branch `development` or `details_model` is merged into `master` (?).
- The first item on Discovery page is selected.
- Search query is cleared on catalog switch on Addons page.
- WASM file size reduced from 416 to 369 KB (gzipped by Netlify).
- Fixed `cargo make bundle` random fails.